### PR TITLE
Fix source file type detection, argument not iterable error

### DIFF
--- a/srtsync/main.py
+++ b/srtsync/main.py
@@ -52,13 +52,13 @@ def main():
     if not output_srt.exists():
         warn("The output subtitle will be overwritten !")
 
-    if is_srt(sourcefile):
+    if is_video(sourcefile):
+        aggressiveness = args.a
+        source, length = extract_voice_activity(sourcefile, aggressiveness=aggressiveness)
+    elif is_srt(sourcefile):
         subs = read_srt(sourcefile)
         source = srt_to_timestamps(subs)
         length = None
-    elif is_video(sourcefile):
-        aggressiveness = args.a
-        source, length = extract_voice_activity(sourcefile, aggressiveness=aggressiveness)
     else:
         raise ValueError("The source must be a subtitle of a video file !")
 

--- a/srtsync/sound.py
+++ b/srtsync/sound.py
@@ -38,7 +38,7 @@ def extract(video, audio):
         audio = Path(audio)
 
     command = ("ffmpeg -loglevel panic -i".split() + [str(video)] +
-               "-ab 160k -ac 1 -ar 48000 -vn".split() + [audio])
+               "-ab 160k -ac 1 -ar 48000 -vn".split() + [str(audio)])
     print("Extracting audio...")
     check_call(command)
 


### PR DESCRIPTION
When detecting a .srt file type, we can only rely on the
UnicodeDecodeError exception; but this won't work if we
allowed a non-Unicode file (with "encoding='latin-1'" e.g.)
Work around this by trying video type first.

On Win32, directly using [audio] will produce a "TypeError:
argument of type 'WindowsPath' is not iterable" error. Fix
this by using [str(audio)].

Signed-off-by: Tarnyko <tarnyko@tarnyko.net>